### PR TITLE
Add digital twin platform prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ChatGPT
 
 This repository contains a simple demand forecasting tool implemented in pure Python.
+It also includes a prototype **Digital Twin platform** demonstrating a modular
+architecture for simulation and machine-learning driven decision support.
 
 ## Overview
 
@@ -24,6 +26,23 @@ python demand_forecasting.py path/to/data.csv -w 3
 
 This will output the forecast for the next period based on the moving average of the
 last `w` data points.
+
+## Digital Twin Prototype
+
+The `digital_twin` package bundles a simplified implementation of the
+"self-learning Digital Twin" outlined in the program specification. It provides
+stubs for data ingestion, hybrid modelling, reinforcement learning and
+decision intelligence.
+
+Instantiate the platform as follows:
+
+```python
+from digital_twin import DigitalTwinPlatform
+
+dt = DigitalTwinPlatform()
+dt.data_fabric.add_source("example_source")
+dt.replay_history()
+```
 
 ## Tests
 

--- a/digital_twin/README.md
+++ b/digital_twin/README.md
@@ -1,0 +1,15 @@
+# Digital Twin Platform (Prototype)
+
+This package contains a lightweight prototype of the self-learning digital twin platform. It is organized into modular layers mirroring the architecture described in the specifications.
+
+## Modules
+
+- `data_fabric.py` – Data ingestion and feature store stubs.
+- `hybrid_model.py` – Hybrid discrete-event simulation with ML surrogate hooks.
+- `learning_control.py` – Calibration and reinforcement learning logic.
+- `decision_intelligence.py` – Predictive and prescriptive analytics.
+- `financial_valuation.py` – Simple financial calculations.
+- `experience_layer.py` – Placeholder dashboard support.
+- `platform.py` – High-level orchestrator tying the components together.
+
+This code is intentionally minimal and intended as a starting point for further development.

--- a/digital_twin/__init__.py
+++ b/digital_twin/__init__.py
@@ -1,0 +1,19 @@
+"""Prototype self-learning Digital Twin platform."""
+
+from .data_fabric import DataFabric
+from .hybrid_model import HybridModel
+from .learning_control import LearningControl
+from .decision_intelligence import DecisionIntelligence
+from .financial_valuation import FinancialValuation
+from .experience_layer import ExperienceLayer
+from .platform import DigitalTwinPlatform
+
+__all__ = [
+    "DataFabric",
+    "HybridModel",
+    "LearningControl",
+    "DecisionIntelligence",
+    "FinancialValuation",
+    "ExperienceLayer",
+    "DigitalTwinPlatform",
+]

--- a/digital_twin/data_fabric.py
+++ b/digital_twin/data_fabric.py
@@ -1,0 +1,19 @@
+class DataFabric:
+    """Ingests and stores various data sources for the digital twin."""
+
+    def __init__(self):
+        self.sources = []
+        self.features = {}
+
+    def add_source(self, source):
+        """Register a new data source."""
+        self.sources.append(source)
+
+    def ingest(self):
+        """Ingest data from registered sources (placeholder implementation)."""
+        for src in self.sources:
+            print(f"Ingesting from {src}")
+
+    def build_feature_store(self):
+        """Create a basic feature store (mock implementation)."""
+        self.features = {src: f"features_from_{src}" for src in self.sources}

--- a/digital_twin/decision_intelligence.py
+++ b/digital_twin/decision_intelligence.py
@@ -1,0 +1,14 @@
+class DecisionIntelligence:
+    """Provides predictive and prescriptive analytics."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def what_if(self, params):
+        """Run a what-if scenario and return results."""
+        return self.model.run_simulation(params)
+
+    def optimize(self):
+        """Placeholder for prescriptive optimization."""
+        print("Running optimizer")
+        return {"optimized": True}

--- a/digital_twin/experience_layer.py
+++ b/digital_twin/experience_layer.py
@@ -1,0 +1,12 @@
+class ExperienceLayer:
+    """User-facing dashboards and interfaces."""
+
+    def __init__(self):
+        self.dashboards = []
+
+    def add_dashboard(self, name):
+        self.dashboards.append(name)
+
+    def display(self):
+        for dash in self.dashboards:
+            print(f"Showing dashboard: {dash}")

--- a/digital_twin/financial_valuation.py
+++ b/digital_twin/financial_valuation.py
@@ -1,0 +1,13 @@
+class FinancialValuation:
+    """Simple financial analytics for the digital twin."""
+
+    def __init__(self):
+        pass
+
+    def activity_based_costing(self, data):
+        """Return a mock unit cost."""
+        return sum(data) / len(data)
+
+    def monte_carlo_pnl(self, trials=100):
+        """Run a placeholder Monte-Carlo simulation."""
+        return {"trials": trials, "pnl": 0}

--- a/digital_twin/hybrid_model.py
+++ b/digital_twin/hybrid_model.py
@@ -1,0 +1,20 @@
+class HybridModel:
+    """Combines discrete-event simulation with ML surrogates."""
+
+    def __init__(self):
+        self.model = None
+
+    def load_process_flow(self, description):
+        """Load or define the process flow for the DES kernel."""
+        self.model = description
+
+    def run_simulation(self, params=None):
+        """Run a placeholder simulation and return mock results."""
+        if not self.model:
+            raise RuntimeError("Process flow not loaded")
+        print("Running simulation with", params)
+        return {"throughput": 100}
+
+    def surrogate_predict(self, state):
+        """Perform a mock prediction using an ML surrogate."""
+        return {"prediction": state}

--- a/digital_twin/learning_control.py
+++ b/digital_twin/learning_control.py
@@ -1,0 +1,16 @@
+class LearningControl:
+    """Handles model calibration and reinforcement learning."""
+
+    def __init__(self, model):
+        self.model = model
+        self.calibration_interval = 10  # minutes
+
+    def calibrate(self):
+        """Placeholder for real-time parameter calibration."""
+        print("Calibrating model parameters")
+
+    def train_rl_agent(self, episodes=10):
+        """Train a reinforcement learning agent in simulation."""
+        for episode in range(episodes):
+            result = self.model.run_simulation()
+            print(f"Episode {episode}: {result}")

--- a/digital_twin/platform.py
+++ b/digital_twin/platform.py
@@ -1,0 +1,32 @@
+from .data_fabric import DataFabric
+from .hybrid_model import HybridModel
+from .learning_control import LearningControl
+from .decision_intelligence import DecisionIntelligence
+from .financial_valuation import FinancialValuation
+from .experience_layer import ExperienceLayer
+
+
+class DigitalTwinPlatform:
+    """High-level orchestrator for the self-learning digital twin."""
+
+    def __init__(self):
+        self.data_fabric = DataFabric()
+        self.model = HybridModel()
+        self.learning = LearningControl(self.model)
+        self.decision = DecisionIntelligence(self.model)
+        self.finance = FinancialValuation()
+        self.experience = ExperienceLayer()
+
+    def replay_history(self):
+        """Example of using the platform to replay history."""
+        self.data_fabric.ingest()
+        return self.model.run_simulation()
+
+    def predict_kpis(self):
+        """Return mock KPI predictions."""
+        return self.model.surrogate_predict({"state": "current"})
+
+    def prescribe_actions(self):
+        """Run optimization and RL training."""
+        self.learning.train_rl_agent(episodes=1)
+        return self.decision.optimize()

--- a/tests/test_digital_twin.py
+++ b/tests/test_digital_twin.py
@@ -1,0 +1,17 @@
+import unittest
+from digital_twin import DigitalTwinPlatform
+
+
+class TestDigitalTwinPlatform(unittest.TestCase):
+    def test_platform_initialization(self):
+        dt = DigitalTwinPlatform()
+        self.assertIsNotNone(dt.data_fabric)
+        self.assertIsNotNone(dt.model)
+        self.assertIsNotNone(dt.learning)
+        self.assertIsNotNone(dt.decision)
+        self.assertIsNotNone(dt.finance)
+        self.assertIsNotNone(dt.experience)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add digital_twin package with layered architecture skeleton
- document the new digital twin prototype
- include basic unit tests for the platform

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_686b9f53acd0832ba34c49af164c0918